### PR TITLE
Add github repo to cabal

### DIFF
--- a/nitro.cabal
+++ b/nitro.cabal
@@ -76,3 +76,7 @@ executable distributed
 
   extensions: ForeignFunctionInterface
   ghc-options: -threaded
+
+source-repository head
+  type: git
+  location: git://github.com/bumptech/nitro-haskell.git


### PR DESCRIPTION
It makes sense to have a direct link to the repo from the package page on hackage
